### PR TITLE
Use tag selector in case title has a space in

### DIFF
--- a/leanblueprint/templates/dep_graph.html
+++ b/leanblueprint/templates/dep_graph.html
@@ -134,7 +134,7 @@ function interactive() {
            var title = d3.select(this).selectAll('title').text().trim();
            $('#statements > div').hide()
            $('.thm').hide();
-           $('#'+title.replace(':', '\\:')+'_modal').show().children().show().children().show();
+           $("[id='" + title.replace(':', '\\:') + '_modal' + "']").show().children().show().children().show();
            $('#statements').show()
         });
 


### PR DESCRIPTION
In https://github.com/PatrickMassot/leanblueprint/blob/master/leanblueprint/templates/dep_graph.html#L137 the code
```
           $('#'+title.replace(':', '\\:')+'_modal').show().children().show().children().show();
```
is used to select elements with a given id, this id is generated from the labels in the tex source, and this fails to select the element if this label contains spaces.
We hit this issue in leanprover-community/flt-regular as the blueprint was converted from some pre-existing notes where the labels did have spaces in.
Following https://stackoverflow.com/questions/596314/jquery-ids-with-spaces we change the selector to allow spaces in the id.

I haven't been able to test this change yet.