### PR TITLE
Emit errors if labels could not be resolved

### DIFF
--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -140,6 +140,9 @@ class uses(Command):
             labels_dict = doc.context.labels
             used = [labels_dict[label]
                     for label in self.attributes['labels'] if label in labels_dict]
+            for label in self.attributes['labels']:
+                if label not in labels_dict:
+                    log.error("Label '" + label + "' could not be resolved")
             node.setUserData('uses', used)
 
         doc.addPostParseCallbacks(10, update_used)


### PR DESCRIPTION
If labels have no referent, emit a plasTeX error instead of simply ignoring the label. Users can, of course, simply ignore this error - it doesn't cause the compilation to stop. This is primarily of interest when refactoring large blueprints, as names of labels are changed frequently. This change has already revealed a few incorrect labels in the [con-nf project](https://github.com/leanprover-community/con-nf).