### PR TITLE
Do not fail when there is an empty `userdata` in the tree

### DIFF
--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -198,7 +198,7 @@ def ProcessOptions(options, document):
                     node.userdata['proved'] = False
 
             for node in nodes:
-                node.userdata['fully_proved'] = all(n.userdata['proved'] or item_kind(n) == 'definition' for n in graph.ancestors(node).union({node}))
+                node.userdata['fully_proved'] = all(not n.userdata or n.userdata['proved'] or item_kind(n) == 'definition' for n in graph.ancestors(node).union({node}))
 
     document.addPostParseCallbacks(150, make_lean_data)
 


### PR DESCRIPTION
I've been running into a problem where the blueprint generation fails (strangely, I have found that it does not fail upon every run) with the error
```
  File "/usr/bin/plastex", line 8, in <module>
    sys.exit(plastex())
             ^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/plasTeX/client.py", line 72, in plastex
    main(sys.argv[1:])
  File "/usr/lib/python3.11/site-packages/plasTeX/client.py", line 52, in main
    run(filename, config)
  File "/usr/lib/python3.11/site-packages/plasTeX/Compile.py", line 90, in run
    tex = parse(filename, config)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/plasTeX/Compile.py", line 85, in parse
    tex.parse()
  File "/usr/lib/python3.11/site-packages/plasTeX/TeX.py", line 428, in parse
    callback()
  File "/usr/lib/python3.11/site-packages/leanblueprint/Packages/blueprint.py", line 201, in make_lean_data
    node.userdata['fully_proved'] = all(n.userdata['proved'] or item_kind(n) == 'definition' for n in graph.ancestors(node).union({node}))
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/leanblueprint/Packages/blueprint.py", line 201, in <genexpr>
    node.userdata['fully_proved'] = all(n.userdata['proved'] or item_kind(n) == 'definition' for n in graph.ancestors(node).union({node}))
                                        ~~~~~~~~~~^^^^^^^^^^
KeyError: 'proved'
```

After poking around a bit, I found that there sometimes are nodes in the dependency graph that have an empty `userdata`.

This pull requests allows the blueprint generation to complete, even when `userdata` is empty. I'm not sure at the moment why this happens, but this seems to be a fix.