### PR TITLE
Fix coloring of definitions

### DIFF
--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -242,10 +242,12 @@ def ProcessOptions(options, document):
             fillcolor = colors['proved'][0]
         elif can_prove and (can_state or stated):
             fillcolor = colors['can_prove'][0]
-        if stated and item_kind(node) == 'definition':
-            fillcolor = colors['defined'][0]
-
-        if fully_proved:
+        if item_kind(node) == 'definition':
+            if stated:
+                fillcolor = colors['defined'][0]
+            elif can_state:
+                fillcolor = colors['can_state'][0]
+        elif fully_proved:
             fillcolor = colors['fully_proved'][0]
         return fillcolor
 


### PR DESCRIPTION
I noticed that definitions that are not formalized get filled green in the dependency graph.

Steps to reproduce:
```
\documentclass{report}

\usepackage[showmore, dep_graph, coverage, project=../../]{blueprint}

\usepackage{amsmath, amsthm}

\theoremstyle{definition}
\newtheorem{definition}{Definition}

\begin{document}

\begin{definition}
\label{test}\lean{test}
test
\end{definition}

\end{document}
```

This PR makes it so definitions are only colored if they are formalized (with leanok), or can be stated.