### PR TITLE
Neutralize the mathlibok command

### DIFF
--- a/leanblueprint/templates/macros/print.tex
+++ b/leanblueprint/templates/macros/print.tex
@@ -13,6 +13,7 @@
 % Dummy macros that make sense only for web version.
 \newcommand{\lean}[1]{}
 \newcommand{\leanok}{}
+\newcommand{\mathlibok}{}
 % Make sure that arguments of \uses and \proves are real labels, by using invisible refs:
 % latex prints a warning if the label is not defined, but nothing is shown in the pdf file.
 % It uses LaTeX3 programming, this is why we use the expl3 package.


### PR DESCRIPTION
I don't know to what extend the mathlibok command is supported in the new version, but I think it wouldn't hurt to neurtralize it in the print version, so it doesn't create any errors when running inv all. And I think the mathlibok command is nice, so I am planning to do some more PRs (for example color customization for the mathlibok nodes)