### PR TITLE
add a lake update at blueprint initialization, remove it from CI

### DIFF
--- a/leanblueprint/client.py
+++ b/leanblueprint/client.py
@@ -302,7 +302,9 @@ def new() -> None:
                 meta if get_config? env = some "dev" then
                 require «doc-gen4» from git
                   "https://github.com/leanprover/doc-gen4" @ "main"'''))
-        console.print("Ok, lakefile is edited.")
+        console.print("Ok, lakefile is edited. Will now get the doc-gen library.")
+        subprocess.run("lake -R -Kenv=dev update",
+                       cwd=str(blueprint_root.parent), check=False, shell=True)
 
 
     workflow_files: List[Path] = []

--- a/leanblueprint/client.py
+++ b/leanblueprint/client.py
@@ -290,10 +290,8 @@ def new() -> None:
                default=True):
         with lakefile_path.open("a") as lf:
             lf.write('\nrequire checkdecls from git "https://github.com/PatrickMassot/checkdecls.git"')
-        console.print("Ok, lakefile is edited. Will now get the declaration check library.")
-        subprocess.run("lake update checkdecls",
-                       cwd=str(blueprint_root.parent), check=False, shell=True)
-
+        console.print("Ok, lakefile is edited.")
+        
     if confirm("Modify lakefile to allow building the documentation on GitHub?",
                default=True):
         with lakefile_path.open("a", encoding="utf8") as lf:
@@ -304,6 +302,9 @@ def new() -> None:
                   "https://github.com/leanprover/doc-gen4" @ "main"'''))
         console.print("Ok, lakefile is edited.")
 
+    console.print("Updating dependencies.")
+    subprocess.run("lake -R -Kenv=dev update",
+                    cwd=str(blueprint_root.parent), check=False, shell=True)
 
     workflow_files: List[Path] = []
     if can_try_ci and confirm("Configure continuous integration to compile blueprint?",

--- a/leanblueprint/client.py
+++ b/leanblueprint/client.py
@@ -302,9 +302,7 @@ def new() -> None:
                 meta if get_config? env = some "dev" then
                 require «doc-gen4» from git
                   "https://github.com/leanprover/doc-gen4" @ "main"'''))
-        console.print("Ok, lakefile is edited. Will now get the doc-gen library.")
-        subprocess.run("lake -R -Kenv=dev update",
-                       cwd=str(blueprint_root.parent), check=False, shell=True)
+        console.print("Ok, lakefile is edited.")
 
 
     workflow_files: List[Path] = []

--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -21,15 +21,12 @@ jobs:
 
       - name: Install elan
         run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:4.5.0
-
-      - name: Update checkdecls
-        run: ~/.elan/bin/lake update checkdecls
-
+      
       - name: Get cache
-        run: ~/.elan/bin/lake -Kenv=dev exe cache get || true
+        run: ~/.elan/bin/lake exe cache get || true
 
       - name: Build project
-        run: ~/.elan/bin/lake -Kenv=dev build {| lib_name |}
+        run: ~/.elan/bin/lake build {| lib_name |}
 
       - name: Cache mathlib docs
         uses: actions/cache@v3

--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -44,7 +44,7 @@ jobs:
             MathlibDoc-
 
       - name: Build documentation
-        run: ~/.elan/bin/lake -Kenv=dev build {| lib_name |}:docs
+        run: ~/.elan/bin/lake -R -Kenv=dev build {| lib_name |}:docs
 
       - name: Build blueprint and copy to `docs/blueprint`
         uses: xu-cheng/texlive-action@v2


### PR DESCRIPTION
Before this PR:
- when creating a new project and using `leanblueprint new`, then pushing the resulting commit, doc build fails.
- At the end of the `leanblueprint new` procedure, the manifest pushed does not contain doc-gen
- CI has a step in which it updates checkdecls.

Tested here: https://github.com/RemyDegenne/test2 (only 2 commits: initial commit then automatically generated "setup blueprint" commit).

The idea: CI should not update any dependency, but should use the same manifest file as in local. Therefore, we should ensure that the `leanblueprint new` command generates and commits a good lake-manifest.

Changes:
- add a `lake -R -Kenv=dev update` at the end of the `leanblueprint new` procedure, to make sure that we generate and then push a full manifest, including doc-gen.
- remove the lake update step from CI
- add a -R flag to the doc build step, because it is needed.
- remove -Kenv=dev options where they are not needed.

New version tested here: https://github.com/RemyDegenne/test (only 2 commits: initial commit then automatically generated "setup blueprint" commit).