### PR TITLE
feat: add cleanup step

### DIFF
--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -14,6 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Build project
     steps:
+      - name: Cleanup
+        run: |
+          find . -name . -o -prune -exec rm -rf -- {} +
+          # Delete all but the 5 most recent toolchains.
+          # Make sure to delete both the `~/.elan/toolchains/X` directory and the `~/.elan/update-hashes/X` file.
+          # Skip symbolic links (`-type d`), the current directory (`! -name .`), and `nightly` and `stable`.
+          if cd ~/.elan/toolchains && find . -maxdepth 1 -type d ! -name . -print0 | xargs -0 ls -1td | grep -v 'nightly$' | grep -v 'stable$' | tail -n +6 | xargs -I {} sh -c 'echo {} && rm -rf "{}" && rm "../update-hashes/{}"'; then
+              : # Do nothing on success
+          else
+              : # Do nothing on failure, but suppress errors
+          fi
+
       - name: Checkout project
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
I [added this step](https://github.com/fpvandoorn/carleson/compare/5d4c9507f08550ca7757594762a9bec9bf9c1817...73aab429f057bcd15ddc155852c5dcec30f3a22f) to the Carleson repository, which fixed an [issue with running out of disk space](https://github.com/fpvandoorn/carleson/actions/runs/9676609250) ([screenshot here](https://leanprover.zulipchat.com/#narrow/stream/442935-Carleson/topic/disk.20space)).
The code is copied from Mathlib4 CI.
