### PR TITLE
fix: use encoding argument

### DIFF
--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -233,7 +233,7 @@ def ProcessOptions(options, document):
                     n) == 'definition' for n in graph.ancestors(node).union({node}))
 
         lean_decls_path = Path(document.userdata['working-dir']).parent/"lean_decls"
-        lean_decls_path.write_text("\n".join(document.userdata.get("lean_decls", [])))
+        lean_decls_path.write_text("\n".join(document.userdata.get("lean_decls", [])), encoding="utf-8")
 
     document.addPostParseCallbacks(150, make_lean_data)
 
@@ -293,7 +293,7 @@ def ProcessOptions(options, document):
         """
         Extend the dependency graph legend defined by the depgraph plugin
         by adding information specific to Lean blueprints. This is registered
-        as a post-parse callback to allow users to redefine colors and their 
+        as a post-parse callback to allow users to redefine colors and their
         descriptions.
         """
         document.userdata['dep_graph']['legend'].extend([

--- a/leanblueprint/client.py
+++ b/leanblueprint/client.py
@@ -116,7 +116,7 @@ class LakefileLean(Lakefile):
 
     def add_checkdecls(self) -> None:
         """see `super.add_checkdecls`"""
-        with self.path.open("a") as lf:
+        with self.path.open("a", encoding="utf-8") as lf:
             lf.write('\nrequire checkdecls from git "https://github.com/PatrickMassot/checkdecls.git"')
 
     def add_docgen(self) -> None:
@@ -440,7 +440,7 @@ def mk_pdf() -> None:
     bbl_path = blueprint_root/"print"/"print.bbl"
     if bbl_path.exists():
         shutil.copy(bbl_path, blueprint_root/"src"/"web.bbl")
-    
+
 @cli.command()
 def pdf() -> None:
     """


### PR DESCRIPTION
Attempting to fix an error I got locally:
```
  File "C:\Users\Floris\AppData\Local\Programs\Python\Python311\Lib\site-packages\leanblueprint\Packages\blueprint.py", line 236, in make_lean_data
    lean_decls_path.write_text("\n".join(document.userdata.get("lean_decls", [])))
  File "C:\Users\Floris\AppData\Local\Programs\Python\Python311\Lib\pathlib.py", line 1079, in write_text
    return f.write(data)
           ^^^^^^^^^^^^^
  File "C:\Users\Floris\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u0398' in position 259: character maps to <undefined>
plasTeX version 3.1
Command 'plastex -c plastex.cfg web.tex' returned non-zero exit status 1.
```