### PR TITLE
Add cache paths

### DIFF
--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -38,6 +38,8 @@ jobs:
             .lake/build/doc/Std
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
+            .lake/build/doc/find
+            .lake/build/doc/*.*
             !.lake/build/doc/declarations/declaration-data-{| lib_name |}*
           key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |


### PR DESCRIPTION
This PR adds `.lake/build/doc/find` and `.lake/build/doc/*.*` to the "Cache mathlib docs" step in order to avoid docs build error such as [this one](https://github.com/fpvandoorn/carleson/actions/runs/9960001011/job/27519323611#step:7:903). 