### PR TITLE
Add `workflow_dispatch` event to blueprint.yml

### DIFF
--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -1,7 +1,10 @@
+name: Blueprint
+
 on:
   push:
     branches:
       - {| master_branch |}
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
This PR adds the `workflow_dispatch` event to our workflow's YAML file, allowing for manual triggering of the workflow. This feature provides the capability to run workflows on demand, in addition to the existing triggers such as `push`, `pull_request`, and scheduled events.

For more detailed information, please refer to the [GitHub documentation on manually running workflows](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).