### PR TITLE
Create `docs` folder only if it's not already present

### DIFF
--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -63,7 +63,7 @@ jobs:
             pip install pygraphviz --global-option=build_ext --global-option="-L/usr/lib/graphviz/" --global-option="-R/usr/lib/graphviz/"
             pip install leanblueprint
             leanblueprint pdf
-            mkdir docs
+            if [ ! -d docs ]; then mkdir docs; fi
             cp blueprint/print/print.pdf docs/blueprint.pdf
             leanblueprint web
             cp -r blueprint/web docs/blueprint


### PR DESCRIPTION
This PR introduces a conditional check to the `mkdir docs` command in the "Build blueprint and copy to `docs/blueprint`" step of the `blueprint.yml` file. The change ensures that the `docs` directory is created only if it does not already exist. 
