### PR TITLE
Set `default-toolchain` to `none`

### DIFF
--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install elan
-        run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:4.5.0
+        run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
 
       - name: Get cache
         run: ~/.elan/bin/lake exe cache get || true


### PR DESCRIPTION
This PR sets `default-toolchain` to `none`. 

Projects using this config: 
- [FLT](https://github.com/ImperialCollegeLondon/FLT)
- [Carleson](https://github.com/fpvandoorn/carleson)
- [PFR](https://github.com/teorth/pfr)