### PR TITLE
correct path for pdf

### DIFF
--- a/leanblueprint/jekyll_templates/_layouts/default.html
+++ b/leanblueprint/jekyll_templates/_layouts/default.html
@@ -11,12 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#157878">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  {% if jekyll.environment == "production" %}
-  <link rel="stylesheet"
-    href="{{ site.github.repository_name | append: '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-  {% else %}
   <link rel="stylesheet" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-  {% endif %}
   {% include head-custom.html %}
 </head>
 

--- a/leanblueprint/jekyll_templates/index.md
+++ b/leanblueprint/jekyll_templates/index.md
@@ -10,6 +10,6 @@ Useful links:
 
 * [Zulip chat for Lean](https://leanprover.zulipchat.com/) for coordination
 * [Blueprint]({{ site.url }}/blueprint/)
-* [Blueprint as pdf]({{ site.url }}/blueprint.pdf)
+* [Blueprint as pdf]({{ site.url }}/blueprint/blueprint.pdf)
 * [Dependency graph]({{ site.url }}/blueprint/dep_graph_document.html)
 * [Doc pages for this repository]({{ site.url }}/docs/)

--- a/leanblueprint/jekyll_templates/index.md
+++ b/leanblueprint/jekyll_templates/index.md
@@ -10,6 +10,6 @@ Useful links:
 
 * [Zulip chat for Lean](https://leanprover.zulipchat.com/) for coordination
 * [Blueprint]({{ site.url }}/blueprint/)
-* [Blueprint as pdf]({{ site.url }}/blueprint/blueprint.pdf)
+* [Blueprint as pdf]({{ site.url }}/blueprint.pdf)
 * [Dependency graph]({{ site.url }}/blueprint/dep_graph_document.html)
 * [Doc pages for this repository]({{ site.url }}/docs/)


### PR DESCRIPTION
I think this needs to be corrected, at least when trying out the blueprint here: 
https://firsching.ch/formal_book/
I needed to change the url.