### PR TITLE
[TEMPLATE]: Fix Jekyll GitHub Metadata API Warning

### DIFF
--- a/leanblueprint/jekyll_templates/_config.yml
+++ b/leanblueprint/jekyll_templates/_config.yml
@@ -31,3 +31,4 @@ repository: {| github_username |}/{| github_projectname |}
 remote_theme: {| jekyll_theme |} 
 plugins:
   - jekyll-remote-theme
+  - jekyll-github-metadata

--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -109,6 +109,8 @@ jobs:
       - name: Build website using Jekyll
         if: env.HOME_PAGE_EXISTS == 'true'
         working-directory: home_page
+        env:
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: JEKYLL_ENV=production bundle exec jekyll build  # Note this will also copy the blueprint and API doc into home_page/_site
 
       - name: "Upload website (API documentation, blueprint and any home page)"


### PR DESCRIPTION
This PR fixes the following Jekyll-related warning. 

![image](https://github.com/user-attachments/assets/88dc5eb2-5686-4b5a-9c7d-e6ab9551b1f2)

Upstreamed from the [EquationalTheories](https://github.com/teorth/equational_theories) project.