### PR TITLE
Reorder legends

### DIFF
--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -297,20 +297,20 @@ def ProcessOptions(options, document):
         descriptions.
         """
         document.userdata['dep_graph']['legend'].extend([
-            (f"{document.userdata['dep_graph']['colors']['can_state'][1]} border",
-             "the <em>statement</em> of this result is ready to be formalized; all prerequisites are done"),
             (f"{document.userdata['dep_graph']['colors']['not_ready'][1]} border",
                 "the <em>statement</em> of this result is not ready to be formalized; the blueprint needs more work"),
-            (f"{document.userdata['dep_graph']['colors']['can_state'][1]} background",
-                "the <em>proof</em> of this result is ready to be formalized; all prerequisites are done"),
+            (f"{document.userdata['dep_graph']['colors']['can_state'][1]} border",
+             "the <em>statement</em> of this result is ready to be formalized; all prerequisites are done"),
             (f"{document.userdata['dep_graph']['colors']['proved'][1]} border",
                 "the <em>statement</em> of this result is formalized"),
+            (f"{document.userdata['dep_graph']['colors']['mathlib'][1]} border",
+                "this is in Mathlib"),
+            (f"{document.userdata['dep_graph']['colors']['can_state'][1]} background",
+                "the <em>proof</em> of this result is ready to be formalized; all prerequisites are done"),
             (f"{document.userdata['dep_graph']['colors']['proved'][1]} background",
                 "the <em>proof</em> of this result is formalized"),
             (f"{document.userdata['dep_graph']['colors']['fully_proved'][1]} background", 
                 "the <em>proof</em> of this result and all its ancestors are formalized"),
-            (f"{document.userdata['dep_graph']['colors']['mathlib'][1]} border",
-                "this is in Mathlib"),
         ])
 
     document.addPostParseCallbacks(150, make_legend)


### PR DESCRIPTION
The current legend content is like

> **Boxes:**
>     definitions
> **Ellipses:**
>     theorems and lemmas
> **Blue border:**
>     the statement of this result is ready to be formalized; all prerequisites are done
> **Orange border:**
>     the statement of this result is not ready to be formalized; the blueprint needs more work
> **Blue background:**
>     the proof of this result is ready to be formalized; all prerequisites are done
> **Green border:**
>     the statement of this result is formalized
> **Green background:**
>     the proof of this result is formalized
> **Dark green background:**
>     the proof of this result and all its ancestors are formalized
> **Dark green border:**
>     this is in Mathlib 

I find the ordering very confusing.

The new ordering is such that it lists all **border** entries before the **background** entries, and in order of increasing completion.

------

Actually I prefer something like this


> **Boxes:**
>     definitions
> **Ellipses:**
>     theorems and lemmas
> **Border:**
>     **Orange:**
>         the statement of this result is not ready to be formalized; the blueprint needs more work
>     **Blue:**
>         the statement of this result is ready to be formalized; all prerequisites are done
>     **Green:**
>         the statement of this result is formalized
>     **Dark green:**
>         this is in Mathlib 
> **Background:**
>     **Blue:**
>         the proof of this result is ready to be formalized; all prerequisites are done
>     **Green:**
>         the proof of this result is formalized
>     **Dark green:**
>         the proof of this result and all its ancestors are formalized


but that appears to require a little more work to implement the three-level hierarchy.