### PR TITLE
[TEMPLATE]: use `leanprover/lean-action` for project build

### DIFF
--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -27,14 +27,8 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
-      - name: Install elan
-        run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-
-      - name: Get Mathlib cache
-        run: ~/.elan/bin/lake exe cache get || true
-
-      - name: Build project
-        run: ~/.elan/bin/lake build {| lib_name |}
+      - name: Build the project
+        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # v1.2.0
 
       - name: Cache API docs
         uses: actions/cache@v4


### PR DESCRIPTION
Replaces manual elan installation and build steps with the `leanprover/lean-action` GitHub Action for building the project. This simplifies the workflow and leverages a maintained action for Lean projects.