### PR TITLE
chore(workflows): fix issues by saving disk space

### DIFF
--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -24,6 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     name: Build project
     steps:
+      - name: Cleanup to free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true # saves approximately 12 GB
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+          
       - name: Checkout project
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build project
     steps:
       - name: Cleanup to free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.0
         with:
           tool-cache: false
           android: true

--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -28,13 +28,13 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
-          android: true # saves approximately 12 GB
+          android: true
           dotnet: false
           haskell: false
           large-packages: false
           docker-images: false
           swap-storage: false
-          
+
       - name: Checkout project
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
This PR adds a job step to save disk space in order to avoid an annoying issue that is arising in many projects. 

Here are a few examples: 
- FLT: https://leanprover.zulipchat.com/#narrow/channel/416277-FLT/topic/build.20failing/near/560941166
- ETP: https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/.22No.20space.20left.20on.20device.22/with/557978753
- https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Lean.20docgen.20build.20error.20when.20deploying.20to.20website/with/564774279