### PR TITLE
Add caching and disk cleanup for faster CI builds, add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,34 @@ __pycache__
 .python-version
 build/
 dist/
+
+# Lake build artifacts
+/.lake
+
+# Blueprint generated files (built by CI)
+blueprint/web/
+blueprint/print/
+blueprint/lean_decls
+blueprint/src/*.paux
+
+# LaTeX auxiliary files (if you build locally)
+blueprint/**/*.aux
+blueprint/**/*.log
+blueprint/**/*.out
+blueprint/**/*.toc
+blueprint/**/*.fdb_latexmk
+blueprint/**/*.fls
+blueprint/**/*.synctex.gz
+
+# Python virtual environment (leanblueprint)
+env/
+venv/
+.venv/
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .python-version
 build/
 dist/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It is in approximate chronological order, at least in the beginning of the list.
 * [Extreme Value Distribution Project](https://kkytola.github.io/ExtremeValueProject/)
 * [Formal proofs from the book](https://firsching.ch/FormalBook/)
 * [Spectral theorem](https://oliver-butterley.github.io/SpectralThm/)
+* [Radii Polynomial](https://ilpreterosso.github.io/LEANearized-RadiiPolynomial/)
 
 ## Installation
 

--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -24,10 +24,37 @@ jobs:
     runs-on: ubuntu-latest
     name: Build project
     steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          df -h
+
       - name: Checkout project
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
+
+      - name: Cache Lake packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.elan
+            .lake/packages
+          key: deps-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lakefile.toml', 'lake-manifest.json') }}
+
+      - name: Cache Lake build outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/build/lib
+            .lake/build/ir
+            .lake/build/bin
+          key: build-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            build-${{ runner.os }}-${{ github.ref }}-
+            build-${{ runner.os }}-
 
       - name: Build and lint project
         uses: leanprover/lean-action@434f25c2f80ded67bba02502ad3a86f25db50709 # 2025-07-02
@@ -35,6 +62,19 @@ jobs:
           build: true
           lint: true
           mk_all-check: true
+
+      - name: Cache API docs
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/build/doc/Mathlib
+            .lake/build/doc/Lean
+            .lake/build/doc/Init
+            .lake/build/doc/Batteries
+            .lake/build/doc/Aesop
+            .lake/build/doc/Qq
+            .lake/build/doc/Std
+          key: docs-${{ hashFiles('lake-manifest.json') }}
 
       - name: Compile blueprint and documentation
         uses: leanprover-community/docgen-action@deed0cdc44dd8e5de07a300773eb751d33e32fc8 # 2025-10-26

--- a/leanblueprint/templates/blueprint.yml
+++ b/leanblueprint/templates/blueprint.yml
@@ -24,13 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Build project
     steps:
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          df -h
-
       - name: Checkout project
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
Adds build caching and disk cleanup to reduce CI build times and prevent disk space issues. 
Adds a `.gitignore` covering build artifacts, generated files, and editor configurations for Lean projects with leanblueprint

## Update on status

Removed the clean up part for #84 is better

## `blueprint.yml` Changes

- **Disk cleanup step**: Removes unused SDK components (~10GB) before checkout to prevent out-of-disk failures during large builds
- **Lake package caching**: Caches `~/.elan` and `.lake/packages`, keyed on `lean-toolchain`, `lakefile.toml`, and `lake-manifest.json`
- **Build output caching**: Caches `.lake/build/{lib,ir,bin}` with SHA-based keys and branch-level fallbacks for incremental builds
- **API docs caching**: Caches dependency documentation (Mathlib, Batteries, etc.), keyed on `lake-manifest.json`

## Verification

Tested on [LEANearized-RadiiPolynomial](https://github.com/IlPreteRosso/LEANearized-RadiiPolynomial)

## Notes

~30min with code cache, ~10min with warm cache. 

## `.gitignore` Changes

- **Lake build artifacts**: `.lake/` directory
- **Blueprint generated files**: `blueprint/web/`, `blueprint/print/`, `lean_decls`, `*.paux`
- **LaTeX auxiliary files**: `*.aux`, `*.log`, `*.toc`, `*.fdb_latexmk`, `*.fls`, `*.synctex.gz`
- **Python virtual environments**: `env/`, `venv/`, `.venv/`
- **Editor files**: `.vscode/`, `.idea/`, vim swap files, `.DS_Store`

## Notes

CI-generated files (`blueprint/web/`, `blueprint/print/`) are ignored since they are built fresh on each workflow run and should not be committed.