### PR TITLE
feat: Add per-node subgraph generation for dependency graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .python-version
 build/
 dist/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ __pycache__
 .python-version
 build/
 dist/
-venv/

--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -441,7 +441,10 @@ def ProcessOptions(options, document):
             return []
     
     # Register callback to generate subgraphs after main graphs are created
+    # Only if subgraph option is enabled (via environment variable)
     # Use a higher priority (lower number) than the main graph generation (110)
     # but after make_lean_data (150) to ensure all node data is ready
-    cb = PackagePreCleanupCB(data=make_subgraph_html)
-    document.addPackageResource(cb)
+    import os
+    if os.environ.get('LEANBLUEPRINT_SUBGRAPH') == '1':
+        cb = PackagePreCleanupCB(data=make_subgraph_html)
+        document.addPackageResource(cb)

--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -403,7 +403,7 @@ def ProcessOptions(options, document):
                 
                 for node in graph.nodes:
                     sub = graph.subgraph(node)  # Use the monkey-patched method
-                    if sub and len(sub.nodes) > 1:  # Only generate if there are dependencies
+                    if sub:  # Generate even for isolated nodes (no dependencies)
                         # Create a safe filename from node ID
                         node_id_safe = node.id.replace(':', '_').replace('/', '_')
                         graph_target = f'subgraph_{node_id_safe}.html'

--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -368,15 +368,11 @@ def ProcessOptions(options, document):
         try:
             # Check if dependency graphs exist
             if 'dep_graph' not in document.userdata:
-                log.warning('No dependency graph data found, skipping subgraph generation')
                 return []
             
             graphs = document.userdata['dep_graph'].get('graphs', {})
             if not graphs:
-                log.info('No dependency graphs found, skipping subgraph generation')
                 return []
-            
-            log.info(f'Found {len(graphs)} dependency graph(s), generating subgraphs...')
             
             # Find template using the same method as depgraph package
             from plastexdepgraph.Packages.depgraph import PKG_DIR as DEPGRAPH_PKG_DIR
@@ -393,21 +389,16 @@ def ProcessOptions(options, document):
                     pass
             
             if not default_tpl_path.exists():
-                log.warning(f'SubGraph template not found at {default_tpl_path}, skipping subgraph generation')
                 return []
             
-            log.info(f'Using template: {default_tpl_path}')
             graph_tpl = Template(default_tpl_path.read_text())
             
             # Get options from document userdata (set by depgraph package)
             reduce_graph = not document.userdata.get('dep_graph', {}).get('nonreducedgraph', False)
-            title = document.userdata.get('dep_graph', {}).get('title', 'Dependencies')
             
             files = []
             total_nodes = 0
             for sec, graph in graphs.items():
-                log.info(f'Processing graph for section: {sec if sec != document else "document"}')
-                log.info(f'  Graph has {len(graph.nodes)} nodes')
                 total_nodes += len(graph.nodes)
                 
                 for node in graph.nodes:
@@ -442,15 +433,11 @@ def ProcessOptions(options, document):
                         ).dump(graph_target)
             
             if files:
-                log.info(f'Generated {len(files)} subgraph HTML files from {total_nodes} total nodes')
-            else:
-                log.info(f'No subgraphs generated (nodes may have no dependencies)')
+                log.info(f'Generated {len(files)} subgraph HTML files from {len(graphs)} graph(s) with {total_nodes} total nodes')
             return files
         
         except Exception as e:
-            import traceback
-            log.error(f'Error generating subgraphs: {e}')
-            log.debug(traceback.format_exc())
+            log.warning(f'Error generating subgraphs: {e}')
             return []
     
     # Register callback to generate subgraphs after main graphs are created

--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -176,35 +176,23 @@ SUBGRAPH_LINK_TPL = Template("""
 def ProcessOptions(options, document):
     """This is called when the package is loaded."""
 
-    # Extend DepGraph class with subgraph method using monkey patching
     def subgraph(self, node):
-        """
-        Create a subgraph containing the given node and all its ancestors (dependencies).
-        Returns a new DepGraph instance, or None if node is not in the graph.
-        """
+        """Return a subgraph containing the node and all its ancestors."""
         if node not in self.nodes:
             return None
-        
-        # Get all ancestor nodes (dependencies)
         ancestor_nodes = self.ancestors(node)
         subgraph_nodes = ancestor_nodes.union({node})
-        
-        # Create new DepGraph instance
         sub = DepGraph()
         sub.document = self.document
         sub.nodes = subgraph_nodes
-        
-        # Only include edges within the subgraph
         for s, t in self.edges:
             if s in subgraph_nodes and t in subgraph_nodes:
                 sub.edges.add((s, t))
         for s, t in self.proof_edges:
             if s in subgraph_nodes and t in subgraph_nodes:
                 sub.proof_edges.add((s, t))
-        
         return sub
-    
-    # Monkey patch: dynamically add method to DepGraph class
+
     DepGraph.subgraph = subgraph
 
     # We want to ensure the depgraph and showmore packages are loaded.
@@ -359,68 +347,47 @@ def ProcessOptions(options, document):
     document.userdata['dep_graph'].setdefault('extra_modal_links_tpl', []).extend([
         LEAN_LINKS_TPL, GITHUB_LINK_TPL, SUBGRAPH_LINK_TPL])
 
-    # Generate subgraph HTML files for each node
     def make_subgraph_html(document):
-        """
-        Generate subgraph HTML files for each node in the dependency graphs.
-        Each subgraph shows the node and all its dependencies.
-        """
+        """Generate subgraph HTML files for each node in the dependency graphs."""
         try:
-            # Check if dependency graphs exist
             if 'dep_graph' not in document.userdata:
                 return []
-            
             graphs = document.userdata['dep_graph'].get('graphs', {})
             if not graphs:
                 return []
-            
-            # Find template using the same method as depgraph package
+
             from plastexdepgraph.Packages.depgraph import PKG_DIR as DEPGRAPH_PKG_DIR
             default_tpl_path = DEPGRAPH_PKG_DIR.parent / 'templates' / 'dep_graph.html'
-            
-            # If not found, try alternative locations
             if not default_tpl_path.exists():
-                # Try to find in installed package location
                 try:
                     import plastexdepgraph
                     depgraph_pkg_dir = Path(plastexdepgraph.__file__).parent
                     default_tpl_path = depgraph_pkg_dir.parent / 'templates' / 'dep_graph.html'
                 except (ImportError, AttributeError):
                     pass
-            
             if not default_tpl_path.exists():
                 return []
-            
+
             graph_tpl = Template(default_tpl_path.read_text())
-            
-            # Get options from document userdata (set by depgraph package)
             reduce_graph = not document.userdata.get('dep_graph', {}).get('nonreducedgraph', False)
-            
+
             files = []
             total_nodes = 0
             for sec, graph in graphs.items():
                 total_nodes += len(graph.nodes)
-                
                 for node in graph.nodes:
-                    sub = graph.subgraph(node)  # Use the monkey-patched method
-                    if sub:  # Generate even for isolated nodes (no dependencies)
-                        # Create a safe filename from node ID
+                    sub = graph.subgraph(node)
+                    if sub:
                         node_id_safe = node.id.replace(':', '_').replace('/', '_')
                         graph_target = f'subgraph_{node_id_safe}.html'
                         files.append(graph_target)
-                        
-                        # Generate DOT representation
                         dot = sub.to_dot(document.userdata['dep_graph'].get('shapes', {'definition': 'box'}))
                         if reduce_graph:
                             dot = dot.tred()
-                        
-                        # Generate subgraph title
                         node_title = node.id.split(':')[-1]
                         if hasattr(node, 'caption') and node.caption:
                             node_title = str(node.caption)
                         subgraph_title = f'Dependencies of {node_title}'
-                        
-                        # Render HTML
                         graph_tpl.stream(
                             graph=sub,
                             dot=dot.to_string(),
@@ -431,19 +398,15 @@ def ProcessOptions(options, document):
                             document=document,
                             config=document.config
                         ).dump(graph_target)
-            
+
             if files:
-                log.info(f'Generated {len(files)} subgraph HTML files from {len(graphs)} graph(s) with {total_nodes} total nodes')
+                log.info(f'Generated {len(files)} subgraph HTML files')
             return files
-        
         except Exception as e:
             log.warning(f'Error generating subgraphs: {e}')
             return []
-    
-    # Register callback to generate subgraphs after main graphs are created
-    # Only if subgraph option is enabled (via environment variable)
-    # Use a higher priority (lower number) than the main graph generation (110)
-    # but after make_lean_data (150) to ensure all node data is ready
+
+    ## Subgraph generation
     import os
     if os.environ.get('LEANBLUEPRINT_SUBGRAPH') == '1':
         cb = PackagePreCleanupCB(data=make_subgraph_html)

--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -17,8 +17,8 @@ from pathlib import Path
 from jinja2 import Template
 from plasTeX import Command
 from plasTeX.Logging import getLogger
-from plasTeX.PackageResource import PackageCss, PackageTemplateDir
-from plastexdepgraph.Packages.depgraph import item_kind
+from plasTeX.PackageResource import PackageCss, PackageTemplateDir, PackagePreCleanupCB
+from plastexdepgraph.Packages.depgraph import item_kind, DepGraph
 
 log = getLogger()
 
@@ -166,9 +166,46 @@ GITHUB_LINK_TPL = Template("""
   {%- endif -%}
 """)
 
+SUBGRAPH_LINK_TPL = Template("""
+  {% set node_id_safe = thm.id.replace(':', '_').replace('/', '_') -%}
+  {% set subgraph_url = 'subgraph_' + node_id_safe + '.html' -%}
+  <a class="subgraph_link" href="{{ subgraph_url }}">View Dependency Graph</a>
+""")
+
 
 def ProcessOptions(options, document):
     """This is called when the package is loaded."""
+
+    # Extend DepGraph class with subgraph method using monkey patching
+    def subgraph(self, node):
+        """
+        Create a subgraph containing the given node and all its ancestors (dependencies).
+        Returns a new DepGraph instance, or None if node is not in the graph.
+        """
+        if node not in self.nodes:
+            return None
+        
+        # Get all ancestor nodes (dependencies)
+        ancestor_nodes = self.ancestors(node)
+        subgraph_nodes = ancestor_nodes.union({node})
+        
+        # Create new DepGraph instance
+        sub = DepGraph()
+        sub.document = self.document
+        sub.nodes = subgraph_nodes
+        
+        # Only include edges within the subgraph
+        for s, t in self.edges:
+            if s in subgraph_nodes and t in subgraph_nodes:
+                sub.edges.add((s, t))
+        for s, t in self.proof_edges:
+            if s in subgraph_nodes and t in subgraph_nodes:
+                sub.proof_edges.add((s, t))
+        
+        return sub
+    
+    # Monkey patch: dynamically add method to DepGraph class
+    DepGraph.subgraph = subgraph
 
     # We want to ensure the depgraph and showmore packages are loaded.
     # We first need to make sure the corresponding plugins are used.
@@ -320,4 +357,80 @@ def ProcessOptions(options, document):
     document.userdata.setdefault('thm_header_hidden_extras_tpl', []).extend([LEAN_DECLS_TPL,
                                                                              GITHUB_ISSUE_TPL])
     document.userdata['dep_graph'].setdefault('extra_modal_links_tpl', []).extend([
-        LEAN_LINKS_TPL, GITHUB_LINK_TPL])
+        LEAN_LINKS_TPL, GITHUB_LINK_TPL, SUBGRAPH_LINK_TPL])
+
+    # Generate subgraph HTML files for each node
+    def make_subgraph_html(document):
+        """
+        Generate subgraph HTML files for each node in the dependency graphs.
+        Each subgraph shows the node and all its dependencies.
+        """
+        try:
+            # Find template using the same method as depgraph package
+            from plastexdepgraph.Packages.depgraph import PKG_DIR as DEPGRAPH_PKG_DIR
+            default_tpl_path = DEPGRAPH_PKG_DIR.parent / 'templates' / 'dep_graph.html'
+            
+            # If not found, try alternative locations
+            if not default_tpl_path.exists():
+                # Try to find in installed package location
+                try:
+                    import plastexdepgraph
+                    depgraph_pkg_dir = Path(plastexdepgraph.__file__).parent
+                    default_tpl_path = depgraph_pkg_dir.parent / 'templates' / 'dep_graph.html'
+                except (ImportError, AttributeError):
+                    pass
+            
+            if not default_tpl_path.exists():
+                log.warning('SubGraph template not found, skipping subgraph generation')
+                return []
+            
+            graph_tpl = Template(default_tpl_path.read_text())
+            reduce_graph = not options.get('nonreducedgraph', False)
+            title = options.get('title', 'Dependencies')
+            
+            files = []
+            for sec, graph in document.userdata['dep_graph']['graphs'].items():
+                for node in graph.nodes:
+                    sub = graph.subgraph(node)  # Use the monkey-patched method
+                    if sub and len(sub.nodes) > 1:  # Only generate if there are dependencies
+                        # Create a safe filename from node ID
+                        node_id_safe = node.id.replace(':', '_').replace('/', '_')
+                        graph_target = f'subgraph_{node_id_safe}.html'
+                        files.append(graph_target)
+                        
+                        # Generate DOT representation
+                        dot = sub.to_dot(document.userdata['dep_graph'].get('shapes', {'definition': 'box'}))
+                        if reduce_graph:
+                            dot = dot.tred()
+                        
+                        # Generate subgraph title
+                        node_title = node.id.split(':')[-1]
+                        if hasattr(node, 'caption') and node.caption:
+                            node_title = str(node.caption)
+                        subgraph_title = f'Dependencies of {node_title}'
+                        
+                        # Render HTML
+                        graph_tpl.stream(
+                            graph=sub,
+                            dot=dot.to_string(),
+                            context=document.context,
+                            title=subgraph_title,
+                            legend=document.userdata['dep_graph']['legend'],
+                            extra_modal_links=document.userdata['dep_graph'].get('extra_modal_links_tpl', []),
+                            document=document,
+                            config=document.config
+                        ).dump(graph_target)
+            
+            if files:
+                log.info(f'Generated {len(files)} subgraph HTML files')
+            return files
+        
+        except Exception as e:
+            log.warning(f'Error generating subgraphs: {e}')
+            return []
+    
+    # Register callback to generate subgraphs after main graphs are created
+    # Use a higher priority (lower number) than the main graph generation (110)
+    # but after make_lean_data (150) to ensure all node data is ready
+    cb = PackagePreCleanupCB(data=make_subgraph_html)
+    document.addPackageResource(cb)

--- a/leanblueprint/client.py
+++ b/leanblueprint/client.py
@@ -511,12 +511,14 @@ def checkdecls() -> None:
 
 
 @cli.command()
-def all() -> None:
+@click.option('--subgraph', is_flag=True, default=False,
+              help='Generate subgraph HTML files for each node showing its dependencies.')
+def all(subgraph: bool) -> None:
     """
     Compile both the pdf and html versions of the blueprint and check declarations.
     """
     mk_pdf()
-    mk_web()
+    mk_web(subgraph=subgraph)
     subprocess.run("lake build",
                    cwd=str(blueprint_root.parent), check=True, shell=True)
     do_checkdecls()

--- a/leanblueprint/client.py
+++ b/leanblueprint/client.py
@@ -479,16 +479,23 @@ def pdf() -> None:
     mk_pdf()
 
 
-def mk_web() -> None:
+def mk_web(subgraph: bool = False) -> None:
     (blueprint_root/"web").mkdir(exist_ok=True)
+    env = os.environ.copy()
+    if subgraph:
+        env['LEANBLUEPRINT_SUBGRAPH'] = '1'
+    else:
+        env.pop('LEANBLUEPRINT_SUBGRAPH', None)
     subprocess.run("plastex -c plastex.cfg web.tex",
-                   cwd=str(blueprint_root/"src"), check=True, shell=True)
+                   cwd=str(blueprint_root/"src"), check=True, shell=True, env=env)
 @cli.command()
-def web() -> None:
+@click.option('--subgraph', is_flag=True, default=False,
+              help='Generate subgraph HTML files for each node showing its dependencies.')
+def web(subgraph: bool) -> None:
     """
     Compile the html version of the blueprint using plasTeX.
     """
-    mk_web()
+    mk_web(subgraph=subgraph)
 
 def do_checkdecls() -> None:
     subprocess.run("lake exe checkdecls blueprint/lean_decls",


### PR DESCRIPTION
## Summary

This PR adds a subgraph generation feature that creates individual dependency graph pages for each node, showing the node and all its ancestors (dependencies).

## Features

- Add `subgraph()` method to `DepGraph` class that returns a new graph containing a node and all its ancestors
- Generate individual HTML pages (`subgraph_<node_id>.html`) for each node in the dependency graph
- Add "View Dependency Graph" link in node modals to navigate to the corresponding subgraph page

## Usage

```
leanblueprint all --subgraph
```
or 
```
leanblueprint web --subgraph
```

## Remark
This is just a small feature I developed in my formalization project to make the theorems I'm interested in clearer. Hope this helps. 😄 